### PR TITLE
Fixes #2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function Store(path) {
 }
 
 Store.prototype.get = function(key) {
-  if (!key) return clone(this.Store);
+  if (key == null) return clone(this.Store);
   return clone(this.Store[key]);
 }
 


### PR DESCRIPTION
The purpose of line 10 is to permit this kind of usage:

```
db.get()
// => returns the whole store
```

Following the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), I think `db.get(null)` and `db.get(undefined)` should also return the entire store. Otherwise, assume the user meant to retrieve a specific key.