### PR TITLE
Fixes issue #1.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ function Store(path) {
 
 Store.prototype.get = function(key) {
   if (!key) return clone(this.Store);
-  if (!this.Store[key]) return;
   return clone(this.Store[key]);
 }
 
@@ -27,6 +26,8 @@ Store.prototype.save = function() {
 }
 
 function clone(data) {
+  // JSON.parse(undefined) throws an error, so handle it explicitly
+  if (data === undefined) return undefined;
   return JSON.parse(JSON.stringify(data));
 }
 


### PR DESCRIPTION
It looks like this line in the original `get` definition

```
 if (!this.Store[key]) return;
```

was designed to avoid `SyntaxError`s when trying to clone `undefined`. Since this is really a concern for `clone`, not `get`, I propose moving the check into the `clone` definition. 

Furthermore, `null` is a legitimate value in JSON, so I propose we just check for `undefined`.